### PR TITLE
Introduce JPA implementation of CustomersSink

### DIFF
--- a/account-service-provider/pom.xml
+++ b/account-service-provider/pom.xml
@@ -30,6 +30,15 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <scope>runtime</scope>
       <optional>true</optional>

--- a/account-service-provider/src/main/java/de/sample/schulung/accounts/persistence/CustomerEntity.java
+++ b/account-service-provider/src/main/java/de/sample/schulung/accounts/persistence/CustomerEntity.java
@@ -1,0 +1,30 @@
+package de.sample.schulung.accounts.persistence;
+
+import de.sample.schulung.accounts.domain.Customer;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity(name = "Customer")
+@Table(name = "CUSTOMERS")
+public class CustomerEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID uuid;
+  private String name;
+  @Column(name = "BIRTH_DATE")
+  private LocalDate dateOfBirth;
+  private Customer.CustomerState state;
+
+}

--- a/account-service-provider/src/main/java/de/sample/schulung/accounts/persistence/CustomerEntityMapper.java
+++ b/account-service-provider/src/main/java/de/sample/schulung/accounts/persistence/CustomerEntityMapper.java
@@ -1,0 +1,27 @@
+package de.sample.schulung.accounts.persistence;
+
+import de.sample.schulung.accounts.domain.Customer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomerEntityMapper {
+
+  CustomerEntity map(Customer source) {
+    var result = new CustomerEntity();
+    result.setUuid(source.getUuid());
+    result.setName(source.getName());
+    result.setDateOfBirth(source.getDateOfBirth());
+    result.setState(source.getState());
+    return result;
+  }
+
+  Customer map(CustomerEntity source) {
+    var result = new Customer();
+    result.setUuid(source.getUuid());
+    result.setName(source.getName());
+    result.setDateOfBirth(source.getDateOfBirth());
+    result.setState(source.getState());
+    return result;
+  }
+
+}

--- a/account-service-provider/src/main/java/de/sample/schulung/accounts/persistence/CustomerEntityRepository.java
+++ b/account-service-provider/src/main/java/de/sample/schulung/accounts/persistence/CustomerEntityRepository.java
@@ -1,0 +1,22 @@
+package de.sample.schulung.accounts.persistence;
+
+import de.sample.schulung.accounts.domain.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface CustomerEntityRepository extends JpaRepository<CustomerEntity, UUID> {
+
+//  @Query("select c from Customer c where c.state = :state")
+//  List<CustomerEntity> findAllCustomersWithState(
+//    @Param("state") Customer.CustomerState state
+//  );
+
+  List<CustomerEntity> findAllByState(Customer.CustomerState state);
+
+  // Stream<CustomerEntity> streamAllByState(Customer.CustomerState state);
+
+}

--- a/account-service-provider/src/main/java/de/sample/schulung/accounts/persistence/JpaCustomersSink.java
+++ b/account-service-provider/src/main/java/de/sample/schulung/accounts/persistence/JpaCustomersSink.java
@@ -1,0 +1,65 @@
+package de.sample.schulung.accounts.persistence;
+
+import de.sample.schulung.accounts.domain.Customer;
+import de.sample.schulung.accounts.domain.CustomersSink;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+public class JpaCustomersSink implements CustomersSink {
+
+  private final CustomerEntityRepository repo;
+  private final CustomerEntityMapper mapper;
+
+  @Override
+  public Stream<Customer> getCustomers() {
+    return repo
+      .findAll()
+      .stream()
+      .map(mapper::map);
+  }
+
+  @Override
+  public Optional<Customer> findCustomerById(UUID uuid) {
+    return repo
+      .findById(uuid)
+      .map(mapper::map);
+  }
+
+  @Override
+  public Stream<Customer> getCustomersByState(Customer.CustomerState state) {
+    return repo
+      .findAllByState(state)
+      .stream()
+      .map(mapper::map);
+  }
+
+  @Override
+  public boolean customerExists(UUID uuid) {
+    return repo
+      .existsById(uuid);
+  }
+
+  @Override
+  public void createCustomer(Customer customer) {
+    var entity = mapper.map(customer);
+    repo.save(entity);
+    customer.setUuid(entity.getUuid());
+  }
+
+  @Override
+  public void replaceCustomer(Customer customer) {
+    var entity = mapper.map(customer);
+    repo.save(entity);
+  }
+
+  @Override
+  public void deleteCustomer(UUID uuid) {
+    repo.deleteById(uuid);
+  }
+}

--- a/account-service-provider/src/main/resources/application-local.yml
+++ b/account-service-provider/src/main/resources/application-local.yml
@@ -2,3 +2,13 @@ application:
   customers:
     initialization:
       enabled: true
+spring:
+  datasource:
+    url: jdbc:h2:./.local-db/customers
+      #h2:
+    #console:
+    #enabled: false
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update

--- a/account-service-provider/src/main/resources/application.yml
+++ b/account-service-provider/src/main/resources/application.yml
@@ -3,6 +3,11 @@ server:
 spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
+  jpa:
+    open-in-view: false
+      # Achtung bei Tests, ggf. eigenes "test"-Profil verwenden
+      # hibernate:
+    # ddl-auto: validate
 application:
   customers:
     initialization:

--- a/account-service-provider/src/test/java/de/sample/schulung/accounts/boundary/AccountsApiTests.java
+++ b/account-service-provider/src/test/java/de/sample/schulung/accounts/boundary/AccountsApiTests.java
@@ -1,22 +1,30 @@
-package de.sample.schulung.accounts;
+package de.sample.schulung.accounts.boundary;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @SpringBootTest
 @AutoConfigureMockMvc
 //@ActiveProfiles("local")
+@AutoConfigureTestDatabase
 class AccountsApiTests {
 
   @Autowired

--- a/account-service-provider/src/test/java/de/sample/schulung/accounts/boundary/AccountsBoundaryTests.java
+++ b/account-service-provider/src/test/java/de/sample/schulung/accounts/boundary/AccountsBoundaryTests.java
@@ -2,30 +2,36 @@ package de.sample.schulung.accounts.boundary;
 
 import de.sample.schulung.accounts.domain.CustomersService;
 import de.sample.schulung.accounts.domain.NotFoundException;
+import de.sample.schulung.accounts.persistence.DisablePersistenceLayer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(
-  // disable initializer for these tests
-  properties = {
-    "application.customers.initialization.enabled=false"
-  }
-)
-@AutoConfigureMockMvc
+@WebMvcTest
+@ComponentScan(basePackageClasses = AccountsBoundaryTests.class)
+@TestPropertySource(properties = {
+  "application.customers.initialization.enabled=false"
+})
+@DisablePersistenceLayer
 public class AccountsBoundaryTests {
 
   @Autowired

--- a/account-service-provider/src/test/java/de/sample/schulung/accounts/boundary/IndexPageTests.java
+++ b/account-service-provider/src/test/java/de/sample/schulung/accounts/boundary/IndexPageTests.java
@@ -1,7 +1,8 @@
-package de.sample.schulung.accounts;
+package de.sample.schulung.accounts.boundary;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase
 public class IndexPageTests {
 
   @Autowired
@@ -21,8 +23,8 @@ public class IndexPageTests {
   @Test
   void shouldRedirectIndexPage() throws Exception {
     var location = mvc.perform(
-      get("/")
-    )
+        get("/")
+      )
       .andExpect(status().isFound())
       .andExpect(header().exists("Location"))
       .andReturn()

--- a/account-service-provider/src/test/java/de/sample/schulung/accounts/domain/CustomersInitializerTests.java
+++ b/account-service-provider/src/test/java/de/sample/schulung/accounts/domain/CustomersInitializerTests.java
@@ -1,5 +1,6 @@
 package de.sample.schulung.accounts.domain;
 
+import de.sample.schulung.accounts.persistence.DisablePersistenceLayer;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -9,10 +10,12 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
 @SpringBootTest(
+  classes = CustomersInitializer.class,
   properties = {
     "application.customers.initialization.enabled=true"
   }
 )
+@DisablePersistenceLayer
 public class CustomersInitializerTests {
 
   @MockBean

--- a/account-service-provider/src/test/java/de/sample/schulung/accounts/domain/CustomersServiceTest.java
+++ b/account-service-provider/src/test/java/de/sample/schulung/accounts/domain/CustomersServiceTest.java
@@ -1,19 +1,25 @@
 package de.sample.schulung.accounts.domain;
 
+import de.sample.schulung.accounts.persistence.DisablePersistenceLayer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.time.LocalDate;
 import java.time.Month;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
 
-@SpringBootTest
+@SpringBootTest(classes = CustomersService.class)
+@DisablePersistenceLayer
 public class CustomersServiceTest {
 
   @Autowired
   CustomersService service;
+  @MockBean
+  CustomersSink sink;
 
   @Test
   void shouldNotCreateInvalidCustomer() {
@@ -24,6 +30,7 @@ public class CustomersServiceTest {
 
     assertThatThrownBy(() -> service.createCustomer(customer))
       .isNotNull();
+    verifyNoInteractions(sink);
 
   }
 

--- a/account-service-provider/src/test/java/de/sample/schulung/accounts/persistence/DisablePersistenceLayer.java
+++ b/account-service-provider/src/test/java/de/sample/schulung/accounts/persistence/DisablePersistenceLayer.java
@@ -1,0 +1,27 @@
+package de.sample.schulung.accounts.persistence;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@EnableAutoConfiguration(
+  exclude = {
+    DataSourceAutoConfiguration.class,
+    DataSourceTransactionManagerAutoConfiguration.class,
+    HibernateJpaAutoConfiguration.class
+  }
+)
+public @interface DisablePersistenceLayer {
+}


### PR DESCRIPTION
 Weiterführende Informationen

- [Beispiel für JPA Entities mit Relationen](https://github.com/ralf-ueberfuhr-ars/spring-data-2023-05-09/tree/main/src/main/java/de/sample/spring/customers/entities) - Achtung: Spring Boot Projekt
- Fallstricke bei JPA:
    - Mapping von Enums
    - 1:n/m:n-Beziehungen werden Lazy (bei Aufruf des Getters) geladen, falls nicht explizit per FetchType anders angegeben
      - Vorsicht bei hashCode()/equals()/toString(), v.a. wenn von Lombok generiert - dann per Lombok-Annotation ausschließen
      - Vorsicht bei MapStruct-Mappern
    - 1:1/n:1-Beziehungen werden Eager (sofort) geladen, falls nicht explizit per FetchType anders angegeben
      - Vorsicht bei großen Daten (CLOBs, BLOBs)